### PR TITLE
Update docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pandoc/ubuntu-latex
+FROM pandoc/latex:latest-ubuntu
 
 LABEL maintainer="Jimmy Chu (chujimmy)"
 


### PR DESCRIPTION
[ubuntu-latex](https://hub.docker.com/r/pandoc/ubuntu-latex) is deprecated.